### PR TITLE
have package install of apt-transport-https avoid resource cloning: CHEF13 compatability

### DIFF
--- a/libraries/nodejs_helper.rb
+++ b/libraries/nodejs_helper.rb
@@ -25,10 +25,6 @@ module NodeJs
       JSON.parse(cmd.run_command.stdout, max_nesting: false)
     end
 
-    def url_valid?(list, package)
-      list.fetch(package, {}).fetch('resolved', '').include?('url')
-    end
-
     def version_valid?(list, package, version)
       (version ? list[package]['version'] == version : true)
     end
@@ -38,7 +34,7 @@ module NodeJs
 
       list = npm_list(package, path, environment)['dependencies']
       # Return true if package installed and installed to good version
-      !list.nil? && list.key?(package) && version_valid?(list, package, version) && url_valid?(list, package)
+      !list.nil? && list.key?(package) && version_valid?(list, package, version)
     end
   end
 end

--- a/recipes/npm_packages.rb
+++ b/recipes/npm_packages.rb
@@ -1,10 +1,11 @@
 node['nodejs']['npm_packages'].each do |pkg|
-  f = nodejs_npm pkg['name'] do
+  pkg_action = pkg.key?('action') ? pkg['action'] : :install
+  f = nodejs_npm "nodejs_npm-#{pkg['name']}-#{pkg_action}" do
     action :nothing
+    package pkg['name']
   end
   pkg.each do |key, value|
     f.send(key, value) unless key == 'name' || key == 'action'
   end
-  action = pkg.key?('action') ? pkg['action'] : :install
-  f.action(action)
+  f.action(pkg_action)
 end if node['nodejs'].key?('npm_packages')

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -1,6 +1,8 @@
 case node['platform_family']
 when 'debian'
-  package 'apt-transport-https'
+  package 'nodejs-apt-transport-https' do
+    package_name 'apt-transport-https'
+  end
 
   apt_repository 'node.js' do
     uri node['nodejs']['repo']


### PR DESCRIPTION
specify a unique resource name for package apt-transport-https and npm_packages because of https://docs.chef.io/deprecations_resource_cloning.html

### Description
Avoid resource cloning because other cookbooks also try to install apt-transport-https and how this cookbook does npm_packages

### Issues Resolved
https://github.com/redguide/nodejs/issues/183
https://github.com/redguide/nodejs/issues/115
https://github.com/redguide/nodejs/issues/153



### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
